### PR TITLE
feat: add Registry by App device setting

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -52,6 +52,21 @@ if ("assets" in customDeviceInfo) {
 // Read settings for home screen mode
 const initialSettings = api.getPreferences();
 let brsHomeMode = !initialSettings?.simulator?.options?.includes("disableHomeScreen");
+// "Registry by App" is a simulator-only concern, not part of brs-engine's deviceInfo, so it is
+// read from preferences and updated live the same way brsHomeMode/setHomeScreenMode is, rather
+// than being added to customDeviceInfo/brs.deviceData.
+let registryByApp = initialSettings?.device?.registryByApp?.includes("enabled") ?? false;
+
+// The un-suffixed Developer Id, kept in sync with the setting (see the "developerId" case in
+// the setDeviceInfo receiver below) and used as the base for every app-scoped id computed by
+// `prepareAppRegistry()`. Never applied to `brs.deviceData.developerId` outside of
+// `prepareAppRegistry()` itself, so a change here only takes effect the next time an app starts.
+let baseDeveloperId = customDeviceInfo.developerId;
+// Fixed reference to what brs-engine's own boot-time loadRegistry() (run once, inside
+// initialize()) built its live, self-updating registry for — used only by prepareAppRegistry()
+// to detect whether its very first call can leave that state untouched. Deliberately not kept
+// in sync with baseDeveloperId above.
+const bootDeveloperId = baseDeveloperId;
 
 // Initialize variables
 const defaultAppInfo = { id: "", path: "", icon: "", running: false };
@@ -163,6 +178,7 @@ async function main() {
             // brs-engine requests the version from the worker as the last step on initialize
             isEngineReady = true;
             if (pendingExecute) {
+                prepareAppRegistry(pendingExecute.filePath);
                 brs.execute(
                     pendingExecute.filePath,
                     pendingExecute.data,
@@ -209,6 +225,55 @@ async function main() {
     brs.redraw(api.isFullScreen());
 }
 
+// True once prepareAppRegistry() has ever rebuilt the registry from localStorage itself. Until
+// then, it can leave brs-engine's own boot-time registry state (SharedArrayBuffer-backed, and
+// kept live by a running app's Flush() calls) untouched — the common case (Registry by App off,
+// Developer Id never changed at runtime) then costs nothing beyond that one-time boot-time load.
+// This must be a one-way switch, never reset back to false: unlike that SharedArrayBuffer, a
+// plain Map (what a rebuild switches to) isn't kept live-updated by a running app's Flush()
+// calls, so once we've rebuilt at all, every later app-start must rebuild again from localStorage
+// even if it lands back on a previously-seen id — reusing an old Map verbatim would serve that
+// app's now-stale prior state instead of what it (or another app under the same id) wrote since.
+let registryEverRebuilt = false;
+
+// Sets the effective Developer Id for the app about to start, and — except for the fast path
+// above — rebuilds the registry the engine hands to that app's worker from whatever is currently
+// in localStorage under that id. Must only be called right before `brs.execute()` (never while
+// an app is running): `deviceData` is captured into a fresh payload on every execute(), so this
+// is what lets both a Developer Id change and "Registry by App" take effect per app-start without
+// a full engine re-initialize — but flipping the id mid-run would make a running app's Read/Write
+// calls land in a different registry namespace than its Flush() expects.
+// `registryBuffer` (the SharedArrayBuffer brs-engine's own boot-time load produces) always wins
+// over `registry` in the worker's setup, so it must be cleared here for a plain Map to be used
+// instead — the worker's registry loader accepts either.
+function prepareAppRegistry(filePath) {
+    let developerId = baseDeveloperId;
+    if (registryByApp) {
+        const app = appList.find((a) => a.path === filePath);
+        const appId = app ? app.id : filePath.hashCode();
+        developerId = `${baseDeveloperId}-${appId}`;
+    }
+    // Mirrors brs-engine's own developerId normalization (BrsDevice.normalizeDeviceInfoValue in
+    // brs.worker.js), applied by the worker before ever using the id as a registry-key prefix —
+    // matching it here keeps this localStorage scan aligned with what a Flush() actually writes.
+    developerId = developerId.replace(".", ":");
+    if (!registryEverRebuilt && developerId === bootDeveloperId) {
+        return;
+    }
+    registryEverRebuilt = true;
+    brs.deviceData.developerId = developerId;
+    const storage = globalThis.localStorage;
+    const registry = new Map();
+    for (let index = 0; index < storage.length; index++) {
+        const key = storage.key(index);
+        if (key?.split(".")[0] === developerId) {
+            registry.set(key, storage.getItem(key) ?? "");
+        }
+    }
+    brs.deviceData.registryBuffer = undefined;
+    brs.deviceData.registry = registry;
+}
+
 // Helper function to get the path of the extension script
 function getExtensionPath(lib) {
     const scripts = document.getElementsByTagName("script");
@@ -252,6 +317,10 @@ api.receive("setDeviceInfo", function (key, value) {
             }
         } else if (key === "locale") {
             setLocaleStatus(value);
+        } else if (key === "developerId") {
+            // Mirrors baseDeveloperId, the source prepareAppRegistry() reads: this only takes
+            // effect the next time an app starts (never mid-run), same as registryByApp.
+            baseDeveloperId = value;
         }
     }
 });
@@ -292,6 +361,7 @@ api.receive("executeFile", function (filePath, data, clear, mute, debug, input) 
             pendingExecute = { filePath: filePath.split("?")[0], data, options, input };
             return;
         }
+        prepareAppRegistry(filePath.split("?")[0]);
         brs.execute(filePath.split("?")[0], data, options, input);
     } catch (error) {
         isAppStarting = false;
@@ -456,6 +526,9 @@ api.receive("setHomeScreenMode", function (enabled) {
             brs.terminate("EXIT_USER_NAV");
         }
     }
+});
+api.receive("setRegistryByApp", function (enabled) {
+    registryByApp = enabled;
 });
 
 // Window Resize Event

--- a/src/app/preloadKeys.js
+++ b/src/app/preloadKeys.js
@@ -67,6 +67,7 @@ const RECEIVE_CHANNELS = [
     "setAudioMute",
     "setPerfStats",
     "setHomeScreenMode",
+    "setRegistryByApp",
     "toggleStatusBar",
     "serverStatus",
     "copyScreenshot",

--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -117,6 +117,7 @@ export function getSettings(window) {
                 RIDA: globalThis.sharedObject.deviceInfo.RIDA,
                 developerId: globalThis.sharedObject.deviceInfo.developerId,
                 developerPwd: "",
+                registryByApp: [],
                 autoPlayEnabled: globalThis.sharedObject.deviceInfo.autoPlayEnabled ? ["enabled"] : [],
             },
             display: {
@@ -548,7 +549,7 @@ export function getSettings(window) {
                                     key: "developerId",
                                     type: "text",
                                     style: { width: "45%" },
-                                    help: "Unique id to segregate registry data, the registry only changes after a reset or app restart",
+                                    help: "Unique id to segregate registry data. Takes effect for the next app that starts — never mid-run.",
                                 },
                                 {
                                     label: "Developer Password",
@@ -558,12 +559,22 @@ export function getSettings(window) {
                                     help: "Password used to encrypt and decrypt the app package source code, needs to be 32 bytes long",
                                 },
                                 {
-                                    label: "Video Auto-Play",
+                                    key: "registryByApp",
+                                    type: "checkbox",
+                                    options: [
+                                        {
+                                            label: "Registry by App",
+                                            value: "enabled",
+                                        },
+                                    ],
+                                    help: "Appends the running app's id to the Developer Id used to segregate registry data. Toggling this changes which registry entries an app sees, nothing already stored is deleted.",
+                                },
+                                {
                                     key: "autoPlayEnabled",
                                     type: "checkbox",
                                     options: [
                                         {
-                                            label: "Enabled",
+                                            label: "Video Auto-Play",
                                             value: "enabled",
                                         },
                                     ],
@@ -1139,12 +1150,18 @@ export function getSettings(window) {
         setDeviceInfo("device", "deviceModel", true);
         setDeviceInfo("device", "clientId", true);
         setDeviceInfo("device", "RIDA", true);
-        setDeviceInfo("device", "developerId"); // Do not notify app to avoid change registry without reset
+        // Safe to notify live: prepareAppRegistry() in app.js only applies developerId when the
+        // next app starts, never to one already running, so this can't corrupt a live registry.
+        setDeviceInfo("device", "developerId", true);
         const autoPlay = preferences.device.autoPlayEnabled.includes("enabled");
         if (globalThis.sharedObject.deviceInfo.autoPlayEnabled !== autoPlay) {
             globalThis.sharedObject.deviceInfo.autoPlayEnabled = autoPlay;
             window.webContents.send("setDeviceInfo", "autoPlayEnabled", autoPlay);
         }
+        // Not deviceInfo (see the default above) and safe to push unconditionally, like
+        // saveSimulatorSettings' setHomeScreenMode above: the renderer only reads this flag
+        // when starting the next app, never while one is running.
+        window.webContents.send("setRegistryByApp", preferences.device.registryByApp.includes("enabled"));
         saveDisplaySettings(window);
         setRemoteKeys(settings.defaults.remote, preferences.remote);
         if (preferences.audio) {

--- a/test/unit/app/__snapshots__/preloadKeys.spec.js.snap
+++ b/test/unit/app/__snapshots__/preloadKeys.spec.js.snap
@@ -53,6 +53,7 @@ exports[`IPC channel whitelists > matches their snapshots 2`] = `
   "setAudioMute",
   "setPerfStats",
   "setHomeScreenMode",
+  "setRegistryByApp",
   "toggleStatusBar",
   "serverStatus",
   "copyScreenshot",

--- a/test/unit/app/preloadKeys.spec.js
+++ b/test/unit/app/preloadKeys.spec.js
@@ -39,7 +39,7 @@ describe("IPC channel whitelists", () => {
 
     it("holds the expected number of channels", () => {
         expect(SEND_CHANNELS).toHaveLength(30);
-        expect(RECEIVE_CHANNELS).toHaveLength(34);
+        expect(RECEIVE_CHANNELS).toHaveLength(35);
     });
 
     it("has no duplicates in either direction", () => {


### PR DESCRIPTION
## Summary
- Adds a "Registry by App" checkbox to the Device settings tab (off by default) that appends the running app's id to the Developer Id used to segregate registry data — the Developer Id shown in Settings, and reported over ECP/telnet/debug, is unaffected.
- Both this setting and a Developer Id change now take effect for the next app that starts, with no device reset or simulator restart needed — the effective id is recomputed in `app.js` right before every `brs.execute()` call, but never while an app is running, since flipping the id mid-run could corrupt its registry.
- The flag itself lives outside `brs-engine`'s `deviceInfo` (a dedicated `setRegistryByApp` IPC channel, mirroring the existing `disableHomeScreen`/`setHomeScreenMode` pattern), since that object's shape belongs to `brs-engine`, not this app.
- For the common case (feature off, Developer Id never changed at runtime), `prepareAppRegistry()` leaves `brs-engine`'s own boot-time, SharedArrayBuffer-backed registry state untouched entirely — it only rebuilds from `localStorage` once a namespace switch is actually needed, and always rebuilds from then on to avoid ever serving another app's stale prior state.

## Known limitation
`ecp.js`'s `/query/registry/:appID` endpoint filters registry entries by the base Developer Id, so it won't surface per-app-suffixed entries while this feature is enabled. Left as a documented limitation — fixing it would mean teaching `ecp.js` the per-app suffix scheme too, which is out of scope for this change.

## Test plan
- [x] `npm run lint`
- [x] `npm run prettier`
- [x] `npm test` (753 passing)
- [ ] Manual: enable "Registry by App", run two different sideloaded apps, confirm each keeps its own registry values (e.g. via `roRegistrySection`) and that ECP `/query/registry` behavior matches the known limitation above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzdM275NF2aq2eU99Et84i