### PR TITLE
fix: stop corrupting zip/bpk package bytes on the executeFile IPC path

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -344,9 +344,6 @@ api.receive("executeFile", function (filePath, data, clear, mute, debug, input) 
             password = settings?.device?.developerPwd ?? "";
             debugState = false;
         }
-        if (fileExt !== "brs") {
-            data = data.buffer;
-        }
         brs.setDebugState(debugState);
         if (brsHomeMode) {
             launchAppId = BRS_HOME_APP_PATH;


### PR DESCRIPTION
## Summary
- The `executeFile` IPC handler in `src/app/app.js` unwrapped incoming zip/bpk file data with `data = data.buffer` before passing it to `brs.execute()`, assuming the `Uint8Array`/`Buffer` delivered over Electron's structured-clone IPC always has `byteOffset === 0` and a backing `ArrayBuffer` sized exactly to the view.
- That assumption doesn't hold: reproduced with Node's `v8.serialize`/`deserialize` (same structured-clone machinery Electron IPC uses), some files came back as a view into a slightly larger, offset backing buffer after the clone. Reading `.buffer` grabbed the whole backing buffer instead of just the view's bytes, shifting the file's contents and causing brs-engine's fflate-based `unzipSync` to misread the ZIP central directory, throwing `unknown compression type <garbage>` on otherwise-valid zips (e.g. `roku-deploy.zip`, `probe-callfunc.zip`).
- The `.brs` path never hit this because it's handed to `new Blob([fileData])`, which correctly respects the view's real `byteOffset`/length regardless of the backing buffer's size. Fix: stop unwrapping to `.buffer` for zip/bpk too, and pass the received typed-array view straight through for every extension — `loadAppZip`'s `new Uint8Array(file)` and `loadSourceCode`'s `new Blob([fileData])` both handle a view correctly.

## Test plan
- [x] `npm run lint`
- [x] `npm run prettier`
- [x] `npm test` (753 tests passing)
- [x] Ran the built app (`electron . -o <zip>`) against two previously-failing zips (`roku-deploy.zip`, `probe-callfunc.zip`) — both now load and launch correctly (window title reflects the loaded app's manifest, DevTools console shows 0 errors) instead of failing with "unknown compression type"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzdM275NF2aq2eU99Et84i